### PR TITLE
Export assetFingerprint method on middleware function

### DIFF
--- a/lib/static-asset.js
+++ b/lib/static-asset.js
@@ -30,8 +30,9 @@ function staticAsset(rootPath, strategy) {
 
 	if(!strategy)
 		strategy = staticAsset.strategies["default"];
-	//Return Express middleware
-	return function(req, res, next) {
+
+	//Express middleware
+	function middleware(req, res, next) {
 		//Check to see if req.url matches a fingerprinted URL
 		var info = fingerprints[req.url];
 		//If this request matches a fingerprint
@@ -115,6 +116,10 @@ function staticAsset(rootPath, strategy) {
 			}
 		}
 	}
+
+	//Export assetFingerprint on middleware function and return middleware
+	middleware.assetFingerprint = assetFingerprint;
+	return middleware;
 };
 
 //Expose cache strategies


### PR DESCRIPTION
I found myself trying to integrate this minimal static asset fingerprinting library (which I love, by the way) with the Less pre-processor for CSS and ran into problems because the `assetFingerprint` method is only available from the request and locals within templates. In writing a custom Less function to wrap `assetFingerprint`, I don't have access to either the request object or the template locals, so I needed a reference to the method another way. This is the simplest change that I could come up with that made things workable.

With this change, I can do something like the following when setting up my middleware:

``` javascript
// 1. Create the static asset middleware and the private in-memory fingerprint cache
var staticAssetMiddleware = staticAsset(assetsPath);

// 2. The assetFingerprint method is exported on the middleware function
var assetFingerprint = staticAssetMiddleware.assetFingerprint;

// 3. Set up other pre-processor middleware here that needs to fingerprint assets here
app.use(...);

// 4. Once the pre-processors have run and the resulting CSS is on the disk, insert the static asset middleware
app.use(staticAssetMiddleware);
```

In my case, my Less middleware setup for step 3 looked like this, for reference:

``` javascript
app.use(lessMiddleware({
  src: path.join(__dirname, 'public'),
  once: app.get('env') !== 'development',
  compress: app.get('env') !== 'development',
  treeFunctions: {
    // Make assetFingerprint available within less stylesheets
    asseturl: function(str) {
      var assetPath = url.resolve('/stylesheets/', str.value);
      var urlString = '"' + staticAssetMiddleware.assetFingerprint(assetPath) + '"';
      return new(less.tree.URL)(new(less.tree.Anonymous)(urlString)); //.eval(this.env);
    },
  },
}));
```

If you have a better suggestion on how to achieve this instead, let me know.
