### PR TITLE
Fix issue with 'NaN' appearing as part of default caching strategy.

### DIFF
--- a/lib/cache-strategies/default.js
+++ b/lib/cache-strategies/default.js
@@ -37,7 +37,7 @@ exports.etag = function(filename) {
 		size = stat.size;
 	}
 	return new Number(size).toString(36) + "-" +
-		new Number(hash(data, "crc32") + 0x80000000).toString(36);
+		parseInt(hash(data, "crc32"), 16).toString(36);
 };
 //Set expiration date to one year from now
 exports.expires = function(filename) {


### PR DESCRIPTION
Thanks to the recent update of node-crc, this fixes #9.
