### PR TITLE
Fix bug where default caching strategy would neglect to cache etags.

### DIFF
--- a/lib/cache-strategies/default.js
+++ b/lib/cache-strategies/default.js
@@ -36,8 +36,10 @@ exports.etag = function(filename) {
 		addToCache(filename, stat);
 		size = stat.size;
 	}
-	return new Number(size).toString(36) + "-" +
+	var etag = new Number(size).toString(36) + "-" +
 		parseInt(hash(data, "crc32"), 16).toString(36);
+	addToCache(filename, {etag: etag});
+	return etag;
 };
 //Set expiration date to one year from now
 exports.expires = function(filename) {


### PR DESCRIPTION
The default caching strategy was neglecting to cache `Etags` headers for files. This led to CRC-32 hashes getting calculated on every template render, which slowed down load times for us considerably.

This also adds a more robust check for production environments, since some teams (like ours) may set `NODE_ENV` to `prod` instead of `production`.
