### PR TITLE
Replace deprecated res.send(status) of express, to res.sendStatus(status...

### DIFF
--- a/lib/static-asset.js
+++ b/lib/static-asset.js
@@ -53,7 +53,7 @@ function staticAsset(rootPath, strategy) {
 			if((req.headers["if-none-match"] && info.etag == req.headers["if-none-match"]) ||
 				(req.headers["if-modified-since"] && info.lastModified.toUTCString() ==
 					req.headers["if-modified-since"]) )
-				return res.send(304);
+				return res.sendStatus(304);
 		}
 		//If req.assetFingerprint is already there, do nothing.
 		if(!req.assetFingerprint)


### PR DESCRIPTION
res.send(status) is now deprecated on express. I've replaced it with the recommended res.sendStatus(status).
