### PR TITLE
fix scope loss causing error in express.

### DIFF
--- a/lib/static-asset.js
+++ b/lib/static-asset.js
@@ -53,7 +53,7 @@ function staticAsset(rootPath, strategy) {
 			if((req.headers["if-none-match"] && info.etag == req.headers["if-none-match"]) ||
 				(req.headers["if-modified-since"] && info.lastModified.toUTCString() ==
 					req.headers["if-modified-since"]) )
-				return (res.sendStatus || res.send)(304);
+				return (res.sendStatus || res.send).call(res, 304);
 		}
 		//If req.assetFingerprint is already there, do nothing.
 		if(!req.assetFingerprint)


### PR DESCRIPTION
The scope is being lost here. Express throws an error
`TypeError: Object #<Object> has no method 'type' at sendStatus (express/lib/response.js:326:8)`
because `this` is no longer pointing to `res`.
