### PR TITLE
Added support for running multiple instances of your web server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Expires).
 
 ### Adding the middleware function
 
-**require('static-asset')(path[, cache])** - Returns an Express middleware
+**require('static-asset')(path[, cache, autoFingerprintRegex])** - Returns an Express middleware
 function that exposes a `req.assetFingerprint` function and adds
 `assetFingerprint` view helper function to `res.locals`.  If any request's URL
 matches a previously generated URL fingerprint, static-asset will attempt to add
@@ -64,6 +64,12 @@ weak and strong caching headers to the HTTP response.
 - `cache` - a "cache strategy" Object, which must implement all "cache
 	strategy" methods, as described below. If `cache` is omitted, the
 	default "cache stategy" is used.
+- `autoFingerprintRegex` - a RegEx for matching Urls that you want a fingerprint created for
+	regardless of whether `req.assetFingerprint()` has been called. This is useful if you have multiple
+	threads because only one thread will call `req.assetFingerprint()` when rendering your view. You must 
+	still call `req.assetFingerprint()` in your view even if you use this parameter otherwise the cache 
+	busting will not work. Example `/^(\/javascript\/|\/css\/).+(\?v=.+)$/ig` matches all urls that start with 
+	`/javascript/' or '/css/' and end with a `?v=xxxx`.
 
 ### A "Cache Strategy" Object
 

--- a/lib/static-asset.js
+++ b/lib/static-asset.js
@@ -1,7 +1,7 @@
 var path = require("path"),
 	fs = require("fs");
 module.exports = staticAsset;
-function staticAsset(rootPath, strategy) {
+function staticAsset(rootPath, strategy, autoFingerprintRegex) {
 	/* Labels are named resources that have been manually assigned a fingerprint by
 		calling `req.assetFingerprint(label, fingerprint, cacheInfo)`
 
@@ -31,10 +31,45 @@ function staticAsset(rootPath, strategy) {
 	if(!strategy)
 		strategy = staticAsset.strategies["default"];
 
+	function registerFingerprint(label) {
+		var info = {};
+		//Try to get a fingerprint using the specified cache strategy
+		var fullPath = path.resolve(rootPath + "/" + (label || this.url) );
+		//Use the "cache strategy" to get a fingerprint
+		//Prefer the use of etag over lastModified when generating fingerprints
+		if(!fs.existsSync(fullPath) )
+			return label;
+		if(strategy.lastModified)
+		{
+			var mdate = info.lastModified = strategy.lastModified(fullPath);
+			mdate.setMilliseconds(0);
+		}
+		if(strategy.etag)
+			info.etag = strategy.etag(fullPath);
+		if(strategy.expires)
+			info.expires = strategy.expires(fullPath);
+		if(strategy.fileFingerprint)
+		{
+			var fingerprint = strategy.fileFingerprint(label, fullPath);
+			fingerprints[fingerprint] = info;
+			return fingerprint;
+		}
+		else
+			return label; //Do not generate a fingerprint
+	}
+
 	//Express middleware
 	function middleware(req, res, next) {
 		//Check to see if req.url matches a fingerprinted URL
 		var info = fingerprints[req.originalUrl];
+
+		//Check if we should automatically register a fingerprint.
+		if (!info && autoFingerprintRegex && req.originalUrl.match(autoFingerprintRegex))
+		{
+			registerFingerprint(req.path);
+			info = fingerprints[req.originalUrl];
+		}
+
 		//If this request matches a fingerprint
 		if(info)
 		{
@@ -90,29 +125,7 @@ function staticAsset(rootPath, strategy) {
 			else
 			{
 				info = {};
-				//Try to get a fingerprint using the specified cache strategy
-				var fullPath = path.resolve(rootPath + "/" + (label || this.url) );
-				//Use the "cache strategy" to get a fingerprint
-				//Prefer the use of etag over lastModified when generating fingerprints
-				if(!fs.existsSync(fullPath) )
-					return label;
-				if(strategy.lastModified)
-				{
-					var mdate = info.lastModified = strategy.lastModified(fullPath);
-					mdate.setMilliseconds(0);
-				}
-				if(strategy.etag)
-					info.etag = strategy.etag(fullPath);
-				if(strategy.expires)
-					info.expires = strategy.expires(fullPath);
-				if(strategy.fileFingerprint)
-				{
-					var fingerprint = strategy.fileFingerprint(label, fullPath);
-					fingerprints[fingerprint] = info;
-					return fingerprint;
-				}
-				else
-					return label; //Do not generate a fingerprint
+				return registerFingerprint.call(this, label);
 			}
 		}
 	}


### PR DESCRIPTION
Not sure if you're interested in this but in my scenario I needed to add support for multiple instances of a web server running.

Without this only the first thread will initially make the `req.assetFingerprint()` calls in your view which populates our collection of `fingerprints`.
The other threads will not have the `fingerprints` collection populated but will likely handle one or more requests for the assets and when they do your strategy will not be applied.

Feel free to use it or not and thanks for creating this package. :)
