### PR TITLE
Export fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Last-Modified, ETag, and Expires).
 
 ## API
 
-static-asset exposes a function `req.assetFingerprint`, which allows one to generate
+static-asset exposes a function `req.assetFingerprint` ( by default, though it can be exported under a different name, in case you want to use the middleware for more than one directory ), which allows one to generate
 and register URL fingerprints for static assets.
 
 Once a URL fingerprint is *registered* with static-asset, any HTTP request for that
@@ -192,6 +192,25 @@ This will render to something like this:
 
 Notice that static-asset added a URL fingerprint (the UNIX timestamp
 1318365481) to the filename.
+
+Alternatively, if you want to use the middleware for more than one folder, you can do so like this:
+
+```javascript
+var express = require('express');
+var app = express();
+var staticAsset = require('static-asset');
+app.use(staticAsset(__dirname + "/public/") );
+app.use(staticAsset(__dirname + "/other-public/", null, "secondaryAssetFingerprint") );
+app.use(express.static(__dirname + "/public/") );
+//... application code follows (routes, etc.)
+```
+And then, in your jade view:
+
+```jade
+script(type="text/javascript", src=assetFingerprint("/client.js") )
+script(type="text/javascript", src=secondaryAssetFingerprint("/client2.js") )
+```
+
 
 ## More Advanced Usage
 

--- a/lib/static-asset.js
+++ b/lib/static-asset.js
@@ -1,7 +1,7 @@
 var path = require("path"),
 	fs = require("fs");
 module.exports = staticAsset;
-function staticAsset(rootPath, strategy) {
+function staticAsset(rootPath, strategy, assetFingerprintName) {
 	/* Labels are named resources that have been manually assigned a fingerprint by
 		calling `req.assetFingerprint(label, fingerprint, cacheInfo)`
 
@@ -56,20 +56,20 @@ function staticAsset(rootPath, strategy) {
 				return (res.sendStatus || res.send).call(res, 304);
 		}
 		//If req.assetFingerprint is already there, do nothing.
-		if(!req.assetFingerprint)
+		if(!req.hasOwnProperty(assetFingerprintName))
 		{
 			//Create req.assetFingerprint
-			req.assetFingerprint = assetFingerprint;
+			req.assetFingerprint = this[assetFingerprintName];
 			//Expose req.assetFingerprint in Express helper
-			res.locals.assetFingerprint = function() {
-				return assetFingerprint.apply(req, arguments);
-			};
+			res.locals[assetFingerprintName] = function() {
+				return this[assetFingerprintName].apply(req, arguments);
+			}.bind(this);
 		}
 		//Run next middleware
 		next();
 	};
 	//req.assetFingerprint function
-	function assetFingerprint(label, fingerprint, cacheInfo) {
+	this[assetFingerprintName] = function(label, fingerprint, cacheInfo) {
 		if(arguments.length > 1)
 		{
 			//Add a label
@@ -118,7 +118,7 @@ function staticAsset(rootPath, strategy) {
 	}
 
 	//Export assetFingerprint on middleware function and return middleware
-	middleware.assetFingerprint = assetFingerprint;
+	middleware[assetFingerprintName] = this[assetFingerprintName];
 	return middleware;
 };
 

--- a/lib/static-asset.js
+++ b/lib/static-asset.js
@@ -28,6 +28,9 @@ function staticAsset(rootPath, strategy, assetFingerprintName) {
 	*/
 	var fingerprints = {};
 
+	if(!assetFingerprintName)
+		assetFingerprintName = "assetFingerprint";
+
 	if(!strategy)
 		strategy = staticAsset.strategies["default"];
 


### PR DESCRIPTION
Hi Blake,
I needed the ability to fingerprint assets from more than one directory, and thus use the middleware multiple times in my code. However, because the middleware was exporting `assetFingerprint`, only assets from one of the folders would be fingerprinted. Thus, I forked the repo, to allow exporting the function under different names. Could you please have a look over the pull request, and if you consider it useful, perhaps consider merging it? :)
As a disclaimer, I'm not a node.js developer, so it might be that my code is not entirely up to community standards. Any feedback would be appreciated.

Thanks for your great work!
